### PR TITLE
Supporting webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-fresco",
   "version": "1.0.14",
   "description": "This is a NativeScript plugin wrapping the popular Fresco library for managing images on Android.",
-  "main": "nativescript-fresco.js",
+  "main": "nativescript-fresco",
   "repository": {
     "type": "git",
     "url": "https://github.com/NativeScript/nativescript-fresco"


### PR DESCRIPTION
In order to be a webpack-discoverable module, we need to remove the `.js` suffix in the package.json `main` attribute. This allows webpack to correctly look for `my-module.android.js` or `my-module.ios.js`.

Details here:
http://docs.nativescript.org/angular/tooling/bundling-with-webpack.html#referencing-platform-specific-modules-from-packagejson