### PR TITLE
chore: add dependecies to @angular/core and rxjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,19 +25,20 @@
     }
   },
   "devDependencies": {
-    "@angular/compiler": "~4.0.2",
-    "@angular/compiler-cli": "~4.0.2",
-    "nativescript-angular": "^3.0.0 || ^2.0.0-rc.1",
-    "tns-core-modules": "^3.0.0 || ^3.0.0-rc.1",
-    "tns-platform-declarations": "^3.0.0 || ^3.0.0-rc.1",
+    "@angular/core": "~4.1.0",
+    "@angular/compiler": "~4.1.0",
+    "@angular/compiler-cli": "~4.1.0",
+    "nativescript-angular": "next",
+    "rxjs": "^5.0.1",
+    "tns-core-modules": "next",
+    "tns-platform-declarations": "next",
     "typescript": "^2.2.2"
   },
   "peerDependencies": {
     "tns-core-modules": "^3.0.0 || >3.2.0-"
   },
   "scripts": {
-    "ngc": "ngc",
-    "prepublish": "npm run ngc"
+    "prepublish": "ngc"
   },
   "keywords": [
     "fresco",


### PR DESCRIPTION
NativeScript-Angular no longer has deps to @angular or rxjs (peerDeps
instead) so we need to add them explicitly.