### PR TITLE
Snapshot-friendly

### DIFF
--- a/nativescript-fresco.android.d.ts
+++ b/nativescript-fresco.android.d.ts
@@ -13,11 +13,13 @@ export declare class ImagePipeline {
     clearDiskCaches(): void;
     android: any;
 }
-export declare class AnimatedImage extends com.facebook.imagepipeline.animated.base.AnimatedDrawable implements commonModule.IAnimatedImage {
+export interface AnimatedImage extends com.facebook.imagepipeline.animated.base.AnimatedDrawable, commonModule.IAnimatedImage {
+    new (): AnimatedImage;
     start(): void;
     stop(): void;
     isRunning(): boolean;
 }
+export declare let AnimatedImage: AnimatedImage;
 export declare class FrescoError implements commonModule.IError {
     private _stringValue;
     private _message;

--- a/nativescript-fresco.android.ts
+++ b/nativescript-fresco.android.ts
@@ -67,7 +67,19 @@ export class ImagePipeline {
     }
 }
 
-export class AnimatedImage extends com.facebook.imagepipeline.animated.base.AnimatedDrawable implements commonModule.IAnimatedImage {
+export interface AnimatedImage extends com.facebook.imagepipeline.animated.base.AnimatedDrawable, commonModule.IAnimatedImage {
+    /*tslint:disable-next-line no-misused-new*/
+    new(): AnimatedImage;
+    start(): void;
+    stop(): void;
+    isRunning(): boolean;
+}
+export let AnimatedImage: AnimatedImage;
+function initializeAnimatedImage() {
+if (AnimatedImage) {
+    return;
+}
+class AnimatedImageImpl extends com.facebook.imagepipeline.animated.base.AnimatedDrawable implements commonModule.IAnimatedImage {
     start(): void {
         super.start();
     }
@@ -80,6 +92,9 @@ export class AnimatedImage extends com.facebook.imagepipeline.animated.base.Anim
         return super.isRunning();
     }
 }
+AnimatedImage = AnimatedImageImpl as any;
+}
+
 
 export class FrescoError implements commonModule.IError {
     private _stringValue;
@@ -183,6 +198,7 @@ export class FrescoDrawee extends commonModule.FrescoDrawee {
     private _android: com.facebook.drawee.view.SimpleDraweeView;
 
     public createNativeView() {
+        initializeAnimatedImage();
         this._android = new com.facebook.drawee.view.SimpleDraweeView(this._context);
         return this._android;
     }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "tns-core-modules": "^3.1.0 || >3.3.0-"
   },
   "scripts": {
-    "prepublish": "ngc",
+    "prepack": "ngc",
     "tsc": "tsc -skipLibCheck"
   },
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
                 "./node_modules/tns-core-modules/*",
                 "./node_modules/*"
             ]
-        }
+        },
+        "skipLibCheck": true
     },
     "filesGlob": [
         "*.ts"


### PR DESCRIPTION
Changes to allow this plugin to be used with android webpack/snapshot.

Java package/namespaces usage evaluated at build time will cause snapshot to fail so must be placed in a function that will not execute until runtime. Additional typing added via interfaces to compensate for the loss of having the class inside a function.