### PR TITLE
fix: Fix for #59 and improved typing

### DIFF
--- a/src/nativescript-fresco-common.d.ts
+++ b/src/nativescript-fresco-common.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="references.d.ts" />
 import { View, Property } from "tns-core-modules/ui/core/view";
 import * as observableModule from "tns-core-modules/data/observable";
 export declare namespace ScaleType {

--- a/src/nativescript-fresco-common.ts
+++ b/src/nativescript-fresco-common.ts
@@ -1,5 +1,3 @@
-/// <reference path="references.d.ts" />
-
 import { View, Property, booleanConverter } from "tns-core-modules/ui/core/view";
 import * as observableModule from "tns-core-modules/data/observable";
 

--- a/src/nativescript-fresco.android-map.d.ts
+++ b/src/nativescript-fresco.android-map.d.ts
@@ -162,11 +162,11 @@ declare namespace com {
 
             namespace core {
                 class ImagePipeline {
-                    isInBitmapMemoryCache(uri: string): boolean;
-                    isInDiskCacheSync(uri: string): boolean;
-                    evictFromMemoryCache(uri: string): void;
-                    evictFromDiskCache(uri: string): void;
-                    evictFromCache(uri: string): void;
+                    isInBitmapMemoryCache(uri: android.net.Uri): boolean;
+                    isInDiskCacheSync(uri: android.net.Uri): boolean;
+                    evictFromMemoryCache(uri: android.net.Uri): void;
+                    evictFromDiskCache(uri: android.net.Uri): void;
+                    evictFromCache(uri: android.net.Uri): void;
                     clearCaches(): void;
                     clearMemoryCaches(): void;
                     clearDiskCaches(): void;

--- a/src/nativescript-fresco.android.ts
+++ b/src/nativescript-fresco.android.ts
@@ -306,7 +306,7 @@ export class FrescoDrawee extends commonModule.FrescoDrawee {
         if (this._android) {
             this._android.setImageURI(null);
             if (this.imageUri) {
-                let uri;
+                let uri: android.net.Uri;
                 if (utils.isFileOrResourcePath(this.imageUri)) {
                     let res = utils.ad.getApplicationContext().getResources();
                     if (!res) {
@@ -327,9 +327,13 @@ export class FrescoDrawee extends commonModule.FrescoDrawee {
                     } else if (this.imageUri.indexOf("/") === 0) {
                         uri = android.net.Uri.parse(`file:${this.imageUri}`);
                     }
-                }
-                if (uri === undefined) {
+                } else {
                     uri = android.net.Uri.parse(this.imageUri);
+                }
+
+                if (!uri) {
+                  console.log(`Warning: uri not valid: ${uri}`);
+                  return;
                 }
 
                 let progressiveRenderingEnabledValue = this.progressiveRenderingEnabled !== undefined ? this.progressiveRenderingEnabled : false;

--- a/src/references.d.ts
+++ b/src/references.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="nativescript-fresco.android-map.d.ts" />

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -17,22 +17,21 @@
         "noImplicitAny": false,
         "noImplicitReturns": true,
         "noImplicitUseStrict": false,
-        "noFallthroughCasesInSwitch": true
+        "noFallthroughCasesInSwitch": true,
+        "skipLibCheck": true
     },
     "filesGlob": [
         "*.ts"
     ],
     "include": [
+        "./node_modules/tns-platform-declarations/android.d.ts",
+        "./nativescript-fresco.android-map.d.ts",
         "./nativescript-fresco-common.ts",
         "./nativescript-fresco.android.ts",
         "./nativescript-fresco.ios.ts",
         "./angular/nativescript-fresco-directives.ts",
         "./angular/nativescript-fresco.module.ts",
-        "./angular/index.ts",
-        "references.d.ts"
-    ],
-    "exclude": [
-        "node_modules"
+        "./angular/index.ts"
     ],
     "atom": {
         "rewriteTsconfig": true


### PR DESCRIPTION
Fix for #59 and improved typing
```
Fatal Exception: com.tns.NativeScriptException
Calling js method onCreateView failed Error: com.facebook.imagepipeline.request.ImageRequestBuilder$BuilderException: Invalid request builder: Resource URI must not be empty com.facebook.imagepipeline.request.ImageRequestBuilder.validate(ImageRequestBuilder.java:277) com.facebook.imagepipeline.request.ImageRequestBuilder.build(ImageRequestBuilder.java:253) com.tns.Runtime.callJSMethodNative(Native Method) com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1100) com.tns.Runtime.callJSMethodImpl(Runtime.java:982) com.tns.Runtime.callJSMethod(Runtime.java:969) com.tns.Runtime.callJSMethod(Runtime.java:953) com.tns.Runtime.callJSMethod(Runtime.java:945) com.tns.FragmentClass.onCreateView(FragmentClass.java:45) android.app.Fragment.performCreateView(Fragment.java:2220) android.app.FragmentManagerImpl.moveToState(FragmentManager.java:973) android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1148) android.app.BackStackRecord.run(BackStackRecord.java:793) android.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1535) android.app.FragmentManagerImpl$1.run(FragmentManager.java:482) android.os.Handler.handleCallback(Handler.java:739) android.os.Handler.dispatchMessage(Handler.java:95) android.os.Looper.loop(Looper.java:148) android.app.ActivityThread.main(ActivityThread.java:5417) java.lang.reflect.Method.invoke(Native Method) com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:742) com.android.internal.os.ZygoteInit.main(ZygoteInit.java:632) File: "<embedded>, line: 36, column: 1105305 StackTrace: Frame: function:'t.initImage', file:'<embedded>', line: 36, column: 1105306 Frame: function:'t.initDrawee', file:'<embedded>', line: 36, column: 1104279 Frame: function:'t.initNativeView', file:'<embedded>', line: 36, column: 1102653 Frame: function:'t.setNativeView', file:'<embedded>', line: 36, column: 1286625 Frame: function:'t._setupUI', file:'<embedded>', line: 36, column: 1286119 Frame: function:'', file:'<embedded>', line: 36, column: 1286374 Frame: function:'t.eachChildView', file:'<embedded>', line: 36, column: 1464842 Frame: function:'n.eachChild', file:'<embedded>', line: 36, column: 1273517 Frame: function:'t._setupUI', file:'<embedded>', line: 36, column: 1286350 Frame: function:'', file:'<embedded>', line: 36, column: 1286374 Frame: function:'t.eachChildView', file:'<embedded>', line: 36, column: 1464842 Frame: function:'n.eachChild', file:'<embedded>', line: 36, column: 1273517 Frame: function:'t._setupUI', file:'<embedded>', line: 36, column: 1286350 Frame: function:'', file:'<embedded>', line: 36, column: 1286374 Frame: function:'t.eachChildView', file:'<embedded>', line: 36, column: 1464842 Frame: function:'n.eachChild', file:'<embedded>', line: 36, column: 1273517 Frame: function:'t._setupUI', file:'<embedded>', line: 36, column: 1286350 Frame: function:'', file:'<embedded>', line: 36, column: 1286374 Frame: function:'t.eachChildView', file:'<embedded>', line: 36, column: 628054 Frame: function:'n.eachChild', file:'<embedded>', line: 36, column: 1273517 Frame: function:'t._setupUI', file:'<embedded>', line: 36, column: 1286350 Frame: function:'', file:'<embedded>', line: 36, column: 1286374 Frame: function:'t.eachChildView', file:'<embedded>', line: 36, column: 1464842 Frame: function:'n.eachChild', file:'<embedded>', line: 36, column: 1273517 Frame: function:'t._setupUI', file:'<embedded>', line: 36, column: 1286350 Frame: function:'', file:'<embedded>', line: 36, column: 1286374 Frame: function:'t.eachChildView', file:'<embedded>', line: 36, column: 628054 Frame: function:'t.eachChildView', file:'<embedded>', line: 36, column: 1448752 Frame: function:'n.eachChild', file:'<embedded>', line: 36, column: 1273517 Frame: function:'t._setupUI', file:'<embedded>', line: 36, column: 1286350 Frame: function:'t._addViewCore', file:'<embedded>', line: 36, column: 1284245 Frame: function:'t._addView', file:'<embedded>', line: 36, column: 1283968 Frame: function:'e.onCreateView', file:'<embedded>', line: 36, column: 560440 Frame: function:'t.onCreateView', file:'<embedded>', line: 36, column: 1316946
com.tns.Runtime.callJSMethodNative (Runtime.java)
com.tns.Runtime.dispatchCallJSMethodNative (Runtime.java:1100)
com.tns.Runtime.callJSMethodImpl (Runtime.java:982)
com.tns.Runtime.callJSMethod (Runtime.java:969)
com.tns.Runtime.callJSMethod (Runtime.java:953)
com.tns.Runtime.callJSMethod (Runtime.java:945)
com.tns.FragmentClass.onCreateView (FragmentClass.java:45)
android.app.Fragment.performCreateView (Fragment.java:2220)
android.app.FragmentManagerImpl.moveToState (FragmentManager.java:973)
android.app.FragmentManagerImpl.moveToState (FragmentManager.java:1148)
android.app.BackStackRecord.run (BackStackRecord.java:793)
android.app.FragmentManagerImpl.execPendingActions (FragmentManager.java:1535)
android.app.FragmentManagerImpl$1.run (FragmentManager.java:482)
android.os.Handler.handleCallback (Handler.java:739)
android.os.Handler.dispatchMessage (Handler.java:95)
android.os.Looper.loop (Looper.java:148)
android.app.ActivityThread.main (ActivityThread.java:5417)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:742)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:632)
```

```
Caused by com.facebook.imagepipeline.request.ImageRequestBuilder$BuilderException
Invalid request builder: Resource URI must not be empty
com.facebook.imagepipeline.request.ImageRequestBuilder.validate (ImageRequestBuilder.java:277)
com.facebook.imagepipeline.request.ImageRequestBuilder.build (ImageRequestBuilder.java:253)
com.tns.Runtime.callJSMethodNative (Runtime.java)
com.tns.Runtime.dispatchCallJSMethodNative (Runtime.java:1100)
com.tns.Runtime.callJSMethodImpl (Runtime.java:982)
com.tns.Runtime.callJSMethod (Runtime.java:969)
com.tns.Runtime.callJSMethod (Runtime.java:953)
com.tns.Runtime.callJSMethod (Runtime.java:945)
com.tns.FragmentClass.onCreateView (FragmentClass.java:45)
android.app.Fragment.performCreateView (Fragment.java:2220)
android.app.FragmentManagerImpl.moveToState (FragmentManager.java:973)
android.app.FragmentManagerImpl.moveToState (FragmentManager.java:1148)
android.app.BackStackRecord.run (BackStackRecord.java:793)
android.app.FragmentManagerImpl.execPendingActions (FragmentManager.java:1535)
android.app.FragmentManagerImpl$1.run (FragmentManager.java:482)
android.os.Handler.handleCallback (Handler.java:739)
android.os.Handler.dispatchMessage (Handler.java:95)
android.os.Looper.loop (Looper.java:148)
android.app.ActivityThread.main (ActivityThread.java:5417)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:742)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:632)
```
