### PR TITLE
Fix issue where setting "aspectRatio" via binding caused images to not show with correct size

### DIFF
--- a/demo-angular/app/components/app.component.html
+++ b/demo-angular/app/components/app.component.html
@@ -1,7 +1,7 @@
 <ActionBar title="NativeScript-Fresco Angular sample app">
 </ActionBar>
 <GridLayout rows="*, auto, auto">
-    <FrescoDrawee #drawee verticalAlignment="center" placeholderImageUri="res://ns_logo" aspectRatio="2" imageUri="http://lorempixel.com/400/200/"></FrescoDrawee>
+    <FrescoDrawee #drawee verticalAlignment="center" placeholderImageUri="res://ns_logo" aspectRatio="2" imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/breakfast1.jpg"></FrescoDrawee>
     <Button text="Animate to 0" row="1" (tap)="onAnimateToZero($event)"></Button>
     <Button text="Animate to 1" row="2" (tap)="onAnimateToOne($event)"></Button>
 </GridLayout>

--- a/demo/app/examples/actualimagescaletype.xml
+++ b/demo/app/examples/actualimagescaletype.xml
@@ -1,6 +1,6 @@
 <fresco:FrescoDrawee xmlns:fresco="nativescript-fresco"
                     verticalAlignment="center"
                     placeholderImageUri="res://ns_logo"
-                    aspectRatio="2"
-                    imageUri="http://lorempixel.com/400/200/"
+                    aspectRatio="1.49"
+                    imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/breakfast1.jpg"
                     actualImageScaleType="centerInside"/>

--- a/demo/app/examples/autoplayanimations.xml
+++ b/demo/app/examples/autoplayanimations.xml
@@ -1,7 +1,9 @@
-<fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
-                    verticalAlignment="center"
-                    placeholderImageUri="res://ns_logo"
-                    width="100"
-                    aspectRatio="0.99"
-                    autoPlayAnimations="true"
-                    imageUri="res://animation"/>
+<GridLayout>
+    <fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
+                        verticalAlignment="center"
+                        placeholderImageUri="res://ns_logo"
+                        width="100"
+                        aspectRatio="0.99"
+                        autoPlayAnimations="true"
+                        imageUri="res://animation"/>
+</GridLayout>

--- a/demo/app/examples/cache.ts
+++ b/demo/app/examples/cache.ts
@@ -6,7 +6,7 @@ import { Label } from "tns-core-modules/ui/label";
 import * as frescoModel from "nativescript-fresco";
 import { writeToOutputLabel } from "./appLogger";
 
-let imageUri = "http://lorempixel.com/400/200/";
+let imageUri = "https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/breakfast1.jpg";
 
 export function onCheckCache(args: EventData) {
     let button = args.object as Button;

--- a/demo/app/examples/cache.xml
+++ b/demo/app/examples/cache.xml
@@ -3,8 +3,8 @@
        <fresco:FrescoDrawee id="frescoDrawee"
                             verticalAlignment="center"
                             placeholderImageUri="res://ns_logo"
-                            aspectRatio="2"
-                            imageUri="http://lorempixel.com/400/200/"/>
+                            aspectRatio="1.49"
+                            imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/breakfast1.jpg"/>
         <Button text="Check cache" textWrap="true" tap="onCheckCache"/>
         <Button text="Clear cache" textWrap="true" tap="onClearCache"/>
         <Button text="Set image" textWrap="true" tap="onSetImage"/>

--- a/demo/app/examples/fade.ts
+++ b/demo/app/examples/fade.ts
@@ -7,5 +7,5 @@ export function onSetTap(args: EventData) {
     let button = args.object as Button;
     let gridLayout = button.parent as StackLayout;
     let frescoDrawee = gridLayout.getViewById("frescoDrawee") as FrescoDrawee;
-    frescoDrawee.imageUri = "http://lorempixel.com/400/400/";
+    frescoDrawee.imageUri = "https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/drink1.jpg";
 }

--- a/demo/app/examples/fade.xml
+++ b/demo/app/examples/fade.xml
@@ -5,5 +5,5 @@
                         xmlns:fresco="nativescript-fresco"
                         fadeDuration="3000"
                         placeholderImageUri="res://ns_logo"
-                        aspectRatio="2"/>
+                        aspectRatio="1.49"/>
 </StackLayout>

--- a/demo/app/examples/failure.xml
+++ b/demo/app/examples/failure.xml
@@ -4,7 +4,7 @@
                         height="200" width="400"
                         placeholderImageUri="res://ns_logo"            
                         failureImageUri="res://ns_logo_black"
-                        aspectRatio="2"
+                        aspectRatio="1.49"
                         showProgressBar="true"
                         failure="onFailure"
                         imageUri="http://error.jpgerror"/>

--- a/demo/app/examples/multiple.xml
+++ b/demo/app/examples/multiple.xml
@@ -1,15 +1,12 @@
- <lv:RadListView xmlns:lv="nativescript-ui-listview" xmlns:fresco="nativescript-fresco" items="{{ dataItems }}">
-    <lv:RadListView.listViewLayout>
-              <lv:ListViewLinearLayout/>
-    </lv:RadListView.listViewLayout>
+ <lv:RadListView xmlns:lv="nativescript-ui-listview" xmlns:fresco="nativescript-fresco" items="{{ dataItems }}" id="listView">
     <lv:RadListView.itemTemplate>
         <GridLayout rows="*, auto">
                 <fresco:FrescoDrawee verticalAlignment="top"
-                                    aspectRatio="2"
+                                    aspectRatio="{{ aspectRatio }}"
                                     backgroundUri="res://ns_logo"
                                     imageUri="{{ imageUri }}"/>
-                <StackLayout backgroundColor="#BBFFFFFF" height="20" verticalAlignment="top" row="1">
-                    <Label text="{{ id }}" verticalAlignment="center" horizontalAlignment="center"/>
+                <StackLayout backgroundColor="#c9c9c9" verticalAlignment="top" row="1">
+                    <Label height="22" text="{{ id }}" verticalAlignment="center" horizontalAlignment="center"/>
                 </StackLayout>
         </GridLayout>
     </lv:RadListView.itemTemplate>

--- a/demo/app/examples/opacity.xml
+++ b/demo/app/examples/opacity.xml
@@ -3,17 +3,17 @@
                 id="opacityDrawee"
                 verticalAlignment="center"
                 placeholderImageUri="res://ns_logo"
-                aspectRatio="2"
+                aspectRatio="1.49"
                 opacity="0.5"
-                imageUri="http://lorempixel.com/400/200/"/>
+                imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/breakfast1.jpg"/>
     <Label text="With css: " row="1"/>
     <fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
                 verticalAlignment="center"
                 row="2"
                 class="opacityDrawee"
                 placeholderImageUri="res://ns_logo"
-                aspectRatio="2"
-                imageUri="http://lorempixel.com/400/200/"/>
+                aspectRatio="1.49"
+                imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/breakfast1.jpg"/>
     <Button text="Set 1" row="3" tap="onSeOpacityTo1"/>
     <Button text="Set 0.5" row="4" tap="onSeOpacityTo05"/>
     <Button text="Set 0.1" row="5" tap="onSeOpacityTo01"/>

--- a/demo/app/examples/progressiverenderingenabled.xml
+++ b/demo/app/examples/progressiverenderingenabled.xml
@@ -1,6 +1,8 @@
-<fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
-                    verticalAlignment="center"
-                    placeholderImageUri="res://ns_logo"
-                    aspectRatio="0.754"
-                    progressiveRenderingEnabled="true"
-                    imageUri="http://pooyak.com/p/progjpeg/jpegload.cgi?o=1"/>
+<GridLayout>
+    <fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
+                        verticalAlignment="center"
+                        placeholderImageUri="res://ns_logo"
+                        aspectRatio="0.754"
+                        progressiveRenderingEnabled="true"
+                        imageUri="http://pooyak.com/p/progjpeg/jpegload.cgi?o=1"/>
+</GridLayout>

--- a/demo/app/examples/roundascircle.xml
+++ b/demo/app/examples/roundascircle.xml
@@ -1,6 +1,6 @@
 <fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
                     verticalAlignment="center"
                     placeholderImageUri="res://ns_logo"
-                    aspectRatio="2"
+                    aspectRatio="1.49"
                     roundAsCircle="true"
-                    imageUri="http://lorempixel.com/400/200/"/>
+                    imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/breakfast2.jpg"/>

--- a/demo/app/examples/roundedcornerradius.xml
+++ b/demo/app/examples/roundedcornerradius.xml
@@ -1,11 +1,13 @@
-<fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
-                    verticalAlignment="center"
-                    placeholderImageUri="res://ns_logo"
-                    margin="10"
-                    aspectRatio="2"
-                    roundedCornerRadius="50"
-                    roundBottomRight="true"
-                    roundBottomLeft="true"
-                    roundTopLeft="true"
-                    roundTopRight="true"
-                    imageUri="http://lorempixel.com/400/200/"/>
+<GridLayout>
+    <fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
+                        verticalAlignment="center"
+                        placeholderImageUri="res://ns_logo"
+                        margin="10"
+                        aspectRatio="1.49"
+                        roundedCornerRadius="50"
+                        roundBottomRight="true"
+                        roundBottomLeft="true"
+                        roundTopLeft="true"
+                        roundTopRight="true"
+                        imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/breakfast2.jpg"/>
+</GridLayout>

--- a/demo/app/examples/showprogressbar.xml
+++ b/demo/app/examples/showprogressbar.xml
@@ -1,8 +1,10 @@
-<fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
-                    verticalAlignment="center"
-                    placeholderImageUri="res://ns_logo"
-                    aspectRatio="0.754"
-                    progressiveRenderingEnabled="true"
-                    showProgressBar="true"
-                    progressBarColor="blue"
-                    imageUri="http://pooyak.com/p/progjpeg/jpegload.cgi?o=1"/>
+<GridLayout>
+    <fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
+                        verticalAlignment="center"
+                        placeholderImageUri="res://ns_logo"
+                        aspectRatio="0.754"
+                        progressiveRenderingEnabled="true"
+                        showProgressBar="true"
+                        progressBarColor="blue"
+                        imageUri="http://pooyak.com/p/progjpeg/jpegload.cgi?o=1"/>
+</GridLayout>

--- a/demo/app/examples/single.xml
+++ b/demo/app/examples/single.xml
@@ -1,5 +1,5 @@
 <fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
                     verticalAlignment="center"
                     placeholderImageUri="res://ns_logo"
-                    aspectRatio="2"
-                    imageUri="http://lorempixel.com/400/200/"/>
+                    aspectRatio="1.49"
+                    imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/dessert1.jpg"/>

--- a/demo/app/examples/size.ts
+++ b/demo/app/examples/size.ts
@@ -13,18 +13,21 @@ class Image {
     }
 }
 
-let uris: Array<Image> = new Array(new Image("http://lorempixel.com/200/200", 1), new Image("http://lorempixel.com/400/200", 2), new Image("http://lorempixel.com/400/400", 1), new Image("http://lorempixel.com/200/400", 0.5));
+let images: Array<Image> = new Array(
+    new Image("https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/drink1.jpg", 1.49),
+    new Image("https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/dessert1.jpg", 0.66),
+    new Image("https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/drink2.jpg", 1.49));
 let currentIndex = 1;
 
 export function onChangeTap(args: EventData) {
     let button = args.object as Button;
     let gridLayout = button.parent as GridLayout;
     let drawee = gridLayout.getViewById("frescoDrawee") as FrescoDrawee;
-    drawee.aspectRatio = uris[currentIndex].aspectRation;
-    drawee.imageUri = uris[currentIndex].uri;
+    drawee.aspectRatio = images[currentIndex].aspectRation;
+    drawee.imageUri = images[currentIndex].uri;
 
     currentIndex++;
-    if (currentIndex >= uris.length) {
+    if (currentIndex >= images.length) {
         currentIndex = 0;
     }
 }

--- a/demo/app/examples/size.xml
+++ b/demo/app/examples/size.xml
@@ -1,11 +1,12 @@
 <ScrollView>
     <StackLayout>
         <Button text="change" tap="onChangeTap"/>
-        <fresco:FrescoDrawee verticalAlignment="center" row="1"
+        <fresco:FrescoDrawee verticalAlignment="center"
+                            row="1"
                             id="frescoDrawee"
                             xmlns:fresco="nativescript-fresco"
-                            imageUri="http://lorempixel.com/200/200"
-                            aspectRatio="1"
+                            imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/drink1.jpg"
+                            aspectRatio="1.49"
                             placeholderImageUri="res://ns_logo"/>
     </StackLayout>
 </ScrollView>

--- a/demo/app/examples/taptoretry.xml
+++ b/demo/app/examples/taptoretry.xml
@@ -2,7 +2,7 @@
                         height="200" width="400"
                         placeholderImageUri="res://ns_logo"            
                         failureImageUri="res://ns_logo_black"
-                        aspectRatio="2"
+                        aspectRatio="1.49"
                         tapToRetryEnabled="true"
                         showProgressBar="true"
                         imageUri="http://error.jpgerror"/>

--- a/demo/app/home/dataItem.ts
+++ b/demo/app/home/dataItem.ts
@@ -1,9 +1,11 @@
 export class DataItem {
     public id: number;
+    public aspectRatio: number;
     public imageUri;
 
-    constructor(id: number, imageUri: string) {
+    constructor(id: number, aspectRatio: number, imageUri: string) {
         this.id = id;
         this.imageUri = imageUri;
+        this.aspectRatio = aspectRatio;
     }
 }

--- a/demo/app/home/home-view-model.ts
+++ b/demo/app/home/home-view-model.ts
@@ -17,7 +17,14 @@ export class ViewModel {
             this._dataItems = new ObservableArray<DataItem>();
 
             for (let i = 1; i <= 50; i++) {
-                this._dataItems.push(new DataItem(i, "http://lorempixel.com/400/200/"));
+                let imageUrl = "https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/dessert1.jpg";
+                let aspectRatio = 0.66;
+                if (i % 2 === 0) {
+                    imageUrl = "https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/drink1.jpg";
+                    aspectRatio = 1.49;
+                }
+
+                this._dataItems.push(new DataItem(i, aspectRatio, imageUrl));
             }
         }
     }

--- a/src/nativescript-fresco.android.ts
+++ b/src/nativescript-fresco.android.ts
@@ -295,7 +295,7 @@ export class FrescoDrawee extends commonModule.FrescoDrawee {
     }
 
     protected onAspectRatioChanged(oldValue: number, newValue: number) {
-
+        this.initImage();
     }
 
     private initDrawee() {

--- a/src/package.json
+++ b/src/package.json
@@ -51,9 +51,11 @@
     "build": "npm i && tsc && npm run ngc",
     "tslint": "cd .. && tslint \"**/*.ts\" --config tslint.json --exclude \"**/node_modules/**\"",
     "plugin.tscwatch": "npm run tsc -- -w",
+    "demo.android": "npm i && npm run tsc && cd ../demo && tns run android --syncAllFiles",
+    "demo.reset": "cd ../demo && rimraf platforms",
     "demo.ng.android": "npm i && npm run tsc && cd ../demo-angular && tns run android --syncAllFiles",
     "demo.ng.reset": "cd ../demo-angular && rimraf platforms",
-    "plugin.prepare": "npm run tsc && cd ../demo-angular && tns plugin remove nativescript-fresco && tns plugin add ../src",
+    "plugin.prepare": "npm run tsc && cd ../demo-angular && tns plugin remove nativescript-fresco && tns plugin add ../src && cd ../demo && tns plugin remove nativescript-fresco && tns plugin add ../src",
     "clean": "cd ../demo-angular && rimraf hooks node_modules platforms && cd ../src && rimraf node_modules && npm run plugin.link",
     "ci.tslint": "npm i && tslint '**/*.ts' --config '../tslint.json' --exclude '**/node_modules/**'"
   },


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Setting the `aspectRatio="{{ aspectRatio }}"` with a binding causes the `FrescoDrawee` to be rendered with very small size

## What is the new behavior?
Setting `aspectRatio` via binding correctly redraws the `FrescoDrawee`

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

