### PR TITLE
Add example that shows how to set a native color filter to the 'FrescoDrawee' and add missing 'android' field to d.ts

### DIFF
--- a/demo/app/examples/nativecolerfilter.ts
+++ b/demo/app/examples/nativecolerfilter.ts
@@ -1,0 +1,13 @@
+import { FrescoDrawee } from "nativescript-fresco";
+
+export function onLoaded(args) {
+    let drawee = args.object as FrescoDrawee;
+    if (drawee.android) {
+        const matrix: android.graphics.ColorMatrix = new android.graphics.ColorMatrix();
+        matrix.setSaturation(0);
+        const filter: android.graphics.ColorMatrixColorFilter = new android.graphics.ColorMatrixColorFilter(
+            matrix
+        );
+        drawee.android.setColorFilter(filter);
+    }
+}

--- a/demo/app/examples/nativecolerfilter.xml
+++ b/demo/app/examples/nativecolerfilter.xml
@@ -1,0 +1,6 @@
+<fresco:FrescoDrawee xmlns:fresco="nativescript-fresco" 
+                    verticalAlignment="center"
+                    loaded="onLoaded"
+                    placeholderImageUri="res://ns_logo"
+                    aspectRatio="1.49"
+                    imageUri="https://raw.githubusercontent.com/NativeScript/nativescript-fresco/master/examples-data/dessert1.jpg"/>

--- a/demo/app/home/home-page.xml
+++ b/demo/app/home/home-page.xml
@@ -100,6 +100,11 @@
             <examples:opacity />
         </TabViewItem.view>
       </TabViewItem>
+      <TabViewItem title="colorfilter">
+        <TabViewItem.view>
+            <examples:nativecolerfilter />
+        </TabViewItem.view>
+      </TabViewItem>
     </TabView.items>
   </TabView>
 </Page>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -52,6 +52,11 @@ export class FrescoDrawee extends viewModule.View {
     updateImageUri(): void;
 
     /**
+     * The native 'com.facebook.drawee.view.SimpleDraweeView' object.
+     */
+    android: any;
+
+    /**
      * String value used for the image URI.
      */
     imageUri: string;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you try to autocomplete the `android` property of the `FrescoDrawee` inside and editor like VS Code, you can't.

## What is the new behavior?
<!-- Describe the changes. -->
Now you can autocomplete the `android` property of the `FrescoDrawee` inside and editor like VS Code. Also you can see how to use the native Android [setColorFilter](https://developer.android.com/reference/android/graphics/drawable/Drawable.html#setColorFilter(int,%20android.graphics.PorterDuff.Mode))

